### PR TITLE
[nasa/nos3#519] Replacing nos_engine_server with nos-engine-server

### DIFF
--- a/Components/Nos3Time/Nos3Time.cpp
+++ b/Components/Nos3Time/Nos3Time.cpp
@@ -17,7 +17,7 @@
 
 /* Constants used for NOS Engine Time and NOS Engine bus */
 
-#define ENGINE_SERVER_URI       "tcp://nos_engine_server:12000"
+#define ENGINE_SERVER_URI       "tcp://nos-engine-server:12000"
 #define ENGINE_BUS_NAME         "command"
 #define TICKS_PER_SECOND        100
 #define POSIX_EPOCH             1760776200 //ADVANCING TIME TO 2025-10-18:00:00 


### PR DESCRIPTION
Submodule of https://github.com/nasa/nos3/pull/701